### PR TITLE
Fix potential null handling in StatsService

### DIFF
--- a/backend/src/main/java/com/wooden/project/controller/StatsController.java
+++ b/backend/src/main/java/com/wooden/project/controller/StatsController.java
@@ -28,10 +28,11 @@ public class StatsController {
 
     @GetMapping("/getYearlySales")
     public Double getYearlySales() {
-        if (statisticsService.getYearlySales() == 0) {
+        double yearlySales = statisticsService.getYearlySales();
+        if (yearlySales == 0) {
             return 0.0;
         }
-        return statisticsService.getYearlySales();
+        return yearlySales;
     }
 
 

--- a/backend/src/main/java/com/wooden/project/service/StatisticsService.java
+++ b/backend/src/main/java/com/wooden/project/service/StatisticsService.java
@@ -6,7 +6,6 @@ import com.wooden.project.repository.VenteRepo;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.time.Year;
 import java.util.List;
 
 @Service
@@ -23,18 +22,21 @@ public class StatisticsService {
 
     public double getWeeklySales() {
         LocalDate oneWeekAgo = LocalDate.now().minusDays(7);
-        return VenteRepo.WeeklySales(oneWeekAgo);
+        Double weeklySales = VenteRepo.WeeklySales(oneWeekAgo);
+        return weeklySales != null ? weeklySales : 0.0;
     }
     public int getNewClients() {
         return VenteRepo.NewClients();
     }
 
     public double getYearlySales() {
-        return VenteRepo.YearlySales();
+        Double yearlySales = VenteRepo.YearlySales();
+        return yearlySales != null ? yearlySales : 0.0;
     }
 
     public double getChiffreAffaire() {
-        return VenteRepo.sumTotalRevenue();
+        Double revenue = VenteRepo.sumTotalRevenue();
+        return revenue != null ? revenue : 0.0;
     }
 
     public List<Ventes> getLast20Sales() {


### PR DESCRIPTION
## Summary
- prevent potential NPE when repository queries return `null`
- reuse yearly sales result in controller instead of calling service twice

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68414f19524c83268c6bbd96c13496ad