### PR TITLE
Fix missing mockito-inline version

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -68,16 +68,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>5.10.0</version>
-			<scope>test</scope>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>5.2.0</version>
+                        <scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-inline</artifactId>
-			<version>5.10.0</version>
-			<scope>test</scope>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-inline</artifactId>
+                        <version>5.2.0</version>
+                        <scope>test</scope>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
## Summary
- update the backend pom to use `mockito-core` and `mockito-inline` version 5.2.0

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848513b86688326b724b8e090d9f7f1