### PR TITLE
Fix WeeklySales parameter type

### DIFF
--- a/backend/src/main/java/com/wooden/project/repository/VenteRepo.java
+++ b/backend/src/main/java/com/wooden/project/repository/VenteRepo.java
@@ -5,13 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
 
 @Repository
 public interface VenteRepo extends JpaRepository<Ventes, Long> {
     @Query("SELECT SUM(v.prix) FROM Ventes v WHERE v.date >= :oneWeekAgo")
-    public Double WeeklySales(LocalDate oneWeekAgo);
+    Double WeeklySales(Date oneWeekAgo);
 
     @Query("SELECT SUM(v.prix) FROM Ventes v WHERE YEAR(v.date) = YEAR(current_date)")
     public Double YearlySales();

--- a/backend/src/main/java/com/wooden/project/service/StatisticsService.java
+++ b/backend/src/main/java/com/wooden/project/service/StatisticsService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.Year;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 
 @Service
@@ -23,7 +25,8 @@ public class StatisticsService {
 
     public double getWeeklySales() {
         LocalDate oneWeekAgo = LocalDate.now().minusDays(7);
-        return VenteRepo.WeeklySales(oneWeekAgo);
+        Date weekStart = Date.from(oneWeekAgo.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        return VenteRepo.WeeklySales(weekStart);
     }
     public int getNewClients() {
         return VenteRepo.NewClients();


### PR DESCRIPTION
## Summary
- convert `getWeeklySales` input to `Date` before database query
- adjust `VenteRepo` `WeeklySales` parameter to match the entity field type

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68486f0b61988326b9ecf818cbc75c61