### PR TITLE
Fix Vite proxy

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -38,19 +38,18 @@ export default defineConfig(async ({ mode }) => {
           template: 'treemap',
         }),
     ].filter(Boolean),
-    server: {
-      open: true,
-      host: true,
-      port: 3001,
-      proxy: {
-        '/api': {
-          target: 'http://localhost:3000',
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/api/, ''),
-          secure: false,
+      server: {
+        open: true,
+        host: true,
+        port: 3001,
+        proxy: {
+          '/api': {
+            target: 'http://localhost:8080',
+            changeOrigin: true,
+            secure: false,
+          },
         },
       },
-    },
     build: {
       target: 'esnext',
       minify: 'esbuild',


### PR DESCRIPTION
## Summary
- proxy frontend `/api` requests directly to the Spring Boot backend

## Testing
- `mvnw test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848717f321c83269b124bc075e5e038