### PR TITLE
Add panier item support

### DIFF
--- a/backend/src/main/java/com/wooden/project/controller/PanierController.java
+++ b/backend/src/main/java/com/wooden/project/controller/PanierController.java
@@ -1,6 +1,7 @@
 package com.wooden.project.controller;
 
 import com.wooden.project.model.Panier;
+import com.wooden.project.model.PanierItem;
 import com.wooden.project.service.PanierService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,7 +31,37 @@ public class PanierController {
 
     @PostMapping
     public Panier createPanier(@RequestBody Panier panier) {
-        return panierService.save(panier);
+        return panierService.createPanierWithItems(panier);
+    }
+
+    @PostMapping("/{id}/items")
+    public PanierItem addItem(@PathVariable Long id, @RequestBody PanierItem item) {
+        return panierService.addItem(id, item);
+    }
+
+    @PutMapping("/items/{itemId}")
+    public PanierItem updateItemQuantity(@PathVariable Long itemId, @RequestParam int quantity) {
+        return panierService.updateItemQuantity(itemId, quantity);
+    }
+
+    @DeleteMapping("/items/{itemId}")
+    public ResponseEntity<Void> deleteItem(@PathVariable Long itemId) {
+        panierService.removeItem(itemId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Panier> updatePanier(@PathVariable Long id, @RequestBody Panier panier) {
+        Optional<Panier> existing = panierService.findById(id);
+        if (existing.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        Panier toUpdate = existing.get();
+        toUpdate.setMode_paiement(panier.getMode_paiement());
+        toUpdate.setPrix_panier(panier.getPrix_panier());
+        toUpdate.setEvent(panier.getEvent());
+        toUpdate.setDate_ajout(panier.getDate_ajout());
+        return ResponseEntity.ok(panierService.createPanierWithItems(toUpdate));
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/wooden/project/model/Panier.java
+++ b/backend/src/main/java/com/wooden/project/model/Panier.java
@@ -1,13 +1,14 @@
 package com.wooden.project.model;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import com.wooden.project.model.User;
 import com.wooden.project.model.evenement;
+import java.util.List;
+import com.wooden.project.model.PanierItem;
 
 /**
  * Panier représente un panier d'achat appartenant à un utilisateur.
@@ -25,9 +26,9 @@ public class Panier {
     @Id
     @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
     private Long id_panier;
-    @ManyToOne
-    @JoinColumn(name="id_produit" , referencedColumnName = "id_produit")
-    private Produit produit;
+
+    @OneToMany(mappedBy = "panier", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PanierItem> items;
 
     @ManyToOne
     @JoinColumn(name = "user_id", referencedColumnName = "id_user")
@@ -43,8 +44,7 @@ public class Panier {
     @Temporal(TemporalType.DATE)
     private Date date_ajout;
 
-    public Panier(Produit produit, User user, Date date_ajout, String mode_paiement, Double prix_panier, evenement event) {
-        this.produit = produit;
+    public Panier(User user, Date date_ajout, String mode_paiement, Double prix_panier, evenement event) {
         this.user = user;
         this.date_ajout = date_ajout;
         this.mode_paiement = mode_paiement;

--- a/backend/src/main/java/com/wooden/project/model/PanierItem.java
+++ b/backend/src/main/java/com/wooden/project/model/PanierItem.java
@@ -1,0 +1,36 @@
+package com.wooden.project.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "panier_items")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PanierItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id_panier_item;
+
+    @ManyToOne
+    @JoinColumn(name = "id_panier", referencedColumnName = "id_panier")
+    private Panier panier;
+
+    @ManyToOne
+    @JoinColumn(name = "id_produit", referencedColumnName = "id_produit")
+    private Produit produit;
+
+    private Integer quantite = 1;
+
+    private Double prix_unitaire;
+
+    public PanierItem(Panier panier, Produit produit, Integer quantite, Double prix_unitaire) {
+        this.panier = panier;
+        this.produit = produit;
+        this.quantite = quantite;
+        this.prix_unitaire = prix_unitaire;
+    }
+}

--- a/backend/src/main/java/com/wooden/project/repository/PanierItemRepository.java
+++ b/backend/src/main/java/com/wooden/project/repository/PanierItemRepository.java
@@ -1,0 +1,12 @@
+package com.wooden.project.repository;
+
+import com.wooden.project.model.PanierItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PanierItemRepository extends JpaRepository<PanierItem, Long> {
+    List<PanierItem> findByPanier_Id_panier(Long idPanier);
+}

--- a/backend/src/main/java/com/wooden/project/service/PanierService.java
+++ b/backend/src/main/java/com/wooden/project/service/PanierService.java
@@ -1,8 +1,13 @@
 package com.wooden.project.service;
 
 import com.wooden.project.model.Panier;
-import com.wooden.project.model.User;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.wooden.project.model.PanierItem;
+import java.util.List;
 
 public interface PanierService extends BaseService<Panier,Long> {
+    Panier createPanierWithItems(Panier panier);
+    PanierItem addItem(Long panierId, PanierItem item);
+    void removeItem(Long itemId);
+    PanierItem updateItemQuantity(Long itemId, int quantity);
+    List<PanierItem> getItems(Long panierId);
 }


### PR DESCRIPTION
## Summary
- support multiple items per cart in backend
- expose endpoints to manage items

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68488e25df488326a9015c4573326fb7