### PR TITLE
Handle null totals in stats service

### DIFF
--- a/backend/src/main/java/com/wooden/project/service/StatisticsService.java
+++ b/backend/src/main/java/com/wooden/project/service/StatisticsService.java
@@ -26,18 +26,21 @@ public class StatisticsService {
     public double getWeeklySales() {
         LocalDate oneWeekAgo = LocalDate.now().minusDays(7);
         Date weekStart = Date.from(oneWeekAgo.atStartOfDay(ZoneId.systemDefault()).toInstant());
-        return panierRepo.weeklySales(weekStart);
+        Double result = panierRepo.weeklySales(weekStart);
+        return result != null ? result : 0.0;
     }
     public int getNewClients() {
         return panierRepo.newClients();
     }
 
     public double getYearlySales() {
-        return panierRepo.yearlySales();
+        Double result = panierRepo.yearlySales();
+        return result != null ? result : 0.0;
     }
 
     public double getChiffreAffaire() {
-        return panierRepo.sumTotalRevenue();
+        Double result = panierRepo.sumTotalRevenue();
+        return result != null ? result : 0.0;
     }
 
     public List<Panier> getLast20Sales() {


### PR DESCRIPTION
## Summary
- avoid `NullPointerException` in `StatisticsService`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68489f3e705c8326b7f0eac523cd0b8b