### PR TITLE
Fix LazyInitializationException by enabling open view

### DIFF
--- a/backend/src/main/java/com/wooden/project/model/Panier.java
+++ b/backend/src/main/java/com/wooden/project/model/Panier.java
@@ -1,6 +1,7 @@
 package com.wooden.project.model;
 
 import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -28,6 +29,7 @@ public class Panier {
     private Long id_panier;
 
     @OneToMany(mappedBy = "panier", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
     private List<PanierItem> items;
 
     @ManyToOne

--- a/backend/src/main/java/com/wooden/project/model/PanierItem.java
+++ b/backend/src/main/java/com/wooden/project/model/PanierItem.java
@@ -1,6 +1,7 @@
 package com.wooden.project.model;
 
 import jakarta.persistence.*;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,6 +18,7 @@ public class PanierItem {
 
     @ManyToOne
     @JoinColumn(name = "id_panier", referencedColumnName = "id_panier")
+    @JsonBackReference
     private Panier panier;
 
     @ManyToOne

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,6 +7,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.open-in-view=false
+spring.jpa.open-in-view=true
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 


### PR DESCRIPTION
## Summary
- keep Hibernate session open for serialization by enabling `spring.jpa.open-in-view`
- avoid recursive JSON serialization in `Panier`/`PanierItem`

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848a2541c9c8326b1361acaf3a84f54