### PR TITLE
Fix PanierItem repository lookup

### DIFF
--- a/backend/src/main/java/com/wooden/project/repository/PanierItemRepository.java
+++ b/backend/src/main/java/com/wooden/project/repository/PanierItemRepository.java
@@ -2,11 +2,26 @@ package com.wooden.project.repository;
 
 import com.wooden.project.model.PanierItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface PanierItemRepository extends JpaRepository<PanierItem, Long> {
-    List<PanierItem> findByPanier_Id_panier(Long idPanier);
+
+    /**
+     * Récupère les items d'un panier à partir de l'identifiant du panier.
+     * <p>
+     * Le nom de la colonne dans l'entité {@code Panier} est {@code id_panier} ce qui
+     * rend la convention de nommage automatique de Spring Data difficile à
+     * utiliser. On définit donc explicitement la requête JPQL afin d'éviter les
+     * erreurs de résolution de propriété lors du démarrage de l'application.
+     *
+     * @param idPanier identifiant du panier
+     * @return liste des {@link PanierItem} liés au panier
+     */
+    @Query("SELECT pi FROM PanierItem pi WHERE pi.panier.id_panier = :idPanier")
+    List<PanierItem> findByPanierId(@Param("idPanier") Long idPanier);
 }

--- a/backend/src/main/java/com/wooden/project/service/PanierServiceImpl.java
+++ b/backend/src/main/java/com/wooden/project/service/PanierServiceImpl.java
@@ -73,6 +73,6 @@ public class PanierServiceImpl extends BaseServiceImpl<Panier,Long> implements P
 
     @Override
     public java.util.List<PanierItem> getItems(Long panierId) {
-        return panierItemRepository.findByPanier_Id_panier(panierId);
+        return panierItemRepository.findByPanierId(panierId);
     }
 }


### PR DESCRIPTION
## Summary
- fix PanierItemRepository query by using explicit JPQL
- update PanierServiceImpl to use new repository method

## Testing
- `mvn test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68493c5ec2fc8326be97f3f3f0ed0c80