### PR TITLE
Fix stats endpoints and connect analysis page

### DIFF
--- a/backend/src/main/java/com/wooden/project/controller/StatsController.java
+++ b/backend/src/main/java/com/wooden/project/controller/StatsController.java
@@ -46,4 +46,19 @@ public class StatsController {
         return statisticsService.getLast20Sales();
     }
 
+    @GetMapping("/getCurrentStock")
+    public int getCurrentStock() {
+        return statisticsService.getCurrentStock();
+    }
+
+    @GetMapping("/getMonthlySales")
+    public double getMonthlySales() {
+        return statisticsService.getMonthlySales();
+    }
+
+    @GetMapping("/getBestSellersLastEvent")
+    public Object getBestSellersLastEvent() {
+        return statisticsService.getBestSellersLastEvent();
+    }
+
 }

--- a/backend/src/main/java/com/wooden/project/model/dto/BestSellerDTO.java
+++ b/backend/src/main/java/com/wooden/project/model/dto/BestSellerDTO.java
@@ -1,0 +1,3 @@
+package com.wooden.project.model.dto;
+
+public record BestSellerDTO(String name, int quantity) {}

--- a/backend/src/main/java/com/wooden/project/repository/PanierItemRepository.java
+++ b/backend/src/main/java/com/wooden/project/repository/PanierItemRepository.java
@@ -24,4 +24,7 @@ public interface PanierItemRepository extends JpaRepository<PanierItem, Long> {
      */
     @Query("SELECT pi FROM PanierItem pi WHERE pi.panier.id_panier = :idPanier")
     List<PanierItem> findByPanierId(@Param("idPanier") Long idPanier);
+
+    @Query("SELECT pi.produit as produit, SUM(pi.quantite) as quantite FROM PanierItem pi WHERE pi.panier.event.eventId = :eventId GROUP BY pi.produit ORDER BY quantite DESC")
+    List<Object[]> findBestSellersForEvent(@Param("eventId") Long eventId);
 }

--- a/backend/src/main/java/com/wooden/project/repository/PanierRepo.java
+++ b/backend/src/main/java/com/wooden/project/repository/PanierRepo.java
@@ -23,5 +23,8 @@ public interface PanierRepo extends JpaRepository<Panier, Long> {
     @Query("SELECT SUM(p.prix_panier) FROM Panier p")
     Double sumTotalRevenue();
 
+    @Query("SELECT SUM(p.prix_panier) FROM Panier p WHERE YEAR(p.dateAjout) = YEAR(current_date) AND MONTH(p.dateAjout) = MONTH(current_date)")
+    Double monthlySales();
+
     List<Panier> findTop20ByOrderByDateAjoutDesc();
 }

--- a/backend/src/main/java/com/wooden/project/repository/StockRepository.java
+++ b/backend/src/main/java/com/wooden/project/repository/StockRepository.java
@@ -7,4 +7,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StockRepository extends JpaRepository<Stock, Long> {
+
+    @org.springframework.data.jpa.repository.Query("SELECT SUM(s.quantite) FROM Stock s")
+    Integer totalQuantity();
 }

--- a/backend/src/main/java/com/wooden/project/repository/eventRepo.java
+++ b/backend/src/main/java/com/wooden/project/repository/eventRepo.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface eventRepo extends JpaRepository<evenement, Long> {
+    evenement findTopByOrderByDateFinDesc();
 }

--- a/frontend/src/api/services/statsService.ts
+++ b/frontend/src/api/services/statsService.ts
@@ -1,11 +1,14 @@
 import apiClient from "../apiClient";
 
 export enum StatsApi {
-	WeeklySales = "/stats/getWeeklySales",
-	NewClients = "/stats/getNewClients",
-	YearlySales = "/stats/getYearlySales",
-	ChiffreAffaire = "/stats/getChiffreAffaire",
-	Last20Sales = "/stats/getLast20Sales",
+        WeeklySales = "/stats/getWeeklySales",
+        NewClients = "/stats/getNewClients",
+        YearlySales = "/stats/getYearlySales",
+        ChiffreAffaire = "/stats/getChiffreAffaire",
+        Last20Sales = "/stats/getLast20Sales",
+        CurrentStock = "/stats/getCurrentStock",
+        MonthlySales = "/stats/getMonthlySales",
+        BestSellersLastEvent = "/stats/getBestSellersLastEvent",
 }
 
 const getWeeklySales = () =>
@@ -16,12 +19,21 @@ const getYearlySales = () =>
 const getChiffreAffaire = () =>
 	apiClient.get<number>({ url: StatsApi.ChiffreAffaire });
 const getLast20Sales = () =>
-	apiClient.get<unknown>({ url: StatsApi.Last20Sales });
+        apiClient.get<unknown>({ url: StatsApi.Last20Sales });
+const getCurrentStock = () =>
+        apiClient.get<number>({ url: StatsApi.CurrentStock });
+const getMonthlySales = () =>
+        apiClient.get<number>({ url: StatsApi.MonthlySales });
+const getBestSellersLastEvent = () =>
+        apiClient.get<any[]>({ url: StatsApi.BestSellersLastEvent });
 
 export default {
-	getWeeklySales,
-	getNewClients,
-	getYearlySales,
-	getChiffreAffaire,
-	getLast20Sales,
+        getWeeklySales,
+        getNewClients,
+        getYearlySales,
+        getChiffreAffaire,
+        getLast20Sales,
+        getCurrentStock,
+        getMonthlySales,
+        getBestSellersLastEvent,
 };

--- a/frontend/src/pages/components/chart/view/chart-bar.tsx
+++ b/frontend/src/pages/components/chart/view/chart-bar.tsx
@@ -1,36 +1,37 @@
 import Chart from "@/components/chart/chart";
 import useChart from "@/components/chart/useChart";
 
-const series = [400, 430, 448, 470, 540, 580, 690, 1100, 1200, 1380];
+type Props = {
+        categories?: string[];
+        data?: number[];
+};
 
-export default function ChartBar() {
-	const chartOptions = useChart({
-		stroke: { show: false },
-		plotOptions: {
-			bar: { horizontal: true, barHeight: "30%" },
-		},
-		xaxis: {
-			categories: [
-				"Italy",
-				"Japan",
-				"China",
-				"Canada",
-				"France",
-				"Germany",
-				"South Korea",
-				"Netherlands",
-				"United States",
-				"United Kingdom",
-			],
-		},
-	});
+const defaultData = [400, 430, 448, 470, 540, 580, 690, 1100, 1200, 1380];
+const defaultCategories = [
+        "Italy",
+        "Japan",
+        "China",
+        "Canada",
+        "France",
+        "Germany",
+        "South Korea",
+        "Netherlands",
+        "United States",
+        "United Kingdom",
+];
 
-	return (
-		<Chart
-			type="bar"
-			series={[{ data: series }]}
-			options={chartOptions}
-			height={320}
-		/>
-	);
+export default function ChartBar({ categories = defaultCategories, data = defaultData }: Props) {
+        const chartOptions = useChart({
+                stroke: { show: false },
+                plotOptions: {
+                        bar: { horizontal: true, barHeight: "30%" },
+                },
+                xaxis: {
+                        categories,
+                },
+        });
+
+        return (
+                <Chart type="bar" series={[{ data }]} options={chartOptions} height={320} />
+        );
 }

--- a/frontend/src/pages/components/chart/view/chart-pie.tsx
+++ b/frontend/src/pages/components/chart/view/chart-pie.tsx
@@ -1,13 +1,17 @@
 import Chart from "@/components/chart/chart";
 import useChart from "@/components/chart/useChart";
 
-const series = [44, 55, 13, 43];
-export default function ChartPie() {
-	const chartOptions = useChart({
-		labels: ["DBZ", "OnePiece", "Europe", "Africa"],
-		legend: {
-			horizontalAlign: "center",
-		},
+type Props = { labels?: string[]; data?: number[] };
+
+const defaultSeries = [44, 55, 13, 43];
+const defaultLabels = ["DBZ", "OnePiece", "Europe", "Africa"];
+
+export default function ChartPie({ labels = defaultLabels, data = defaultSeries }: Props) {
+        const chartOptions = useChart({
+                labels,
+                legend: {
+                        horizontalAlign: "center",
+                },
 		stroke: {
 			show: false,
 		},
@@ -31,7 +35,5 @@ export default function ChartPie() {
 		},
 	});
 
-	return (
-		<Chart type="pie" series={series} options={chartOptions} height={320} />
-	);
+        return <Chart type="pie" series={data} options={chartOptions} height={320} />;
 }

--- a/frontend/src/pages/dashboard/analysis/index.tsx
+++ b/frontend/src/pages/dashboard/analysis/index.tsx
@@ -28,14 +28,26 @@ function Analysis() {
 		queryKey: ["newClients"],
 		queryFn: statsService.getNewClients,
 	});
-	const { data: yearlySales } = useQuery({
-		queryKey: ["yearlySales"],
-		queryFn: statsService.getYearlySales,
-	});
-	const { data: weeklySales } = useQuery({
-		queryKey: ["weeklySales"],
-		queryFn: statsService.getWeeklySales,
-	});
+        const { data: yearlySales } = useQuery({
+                queryKey: ["yearlySales"],
+                queryFn: statsService.getYearlySales,
+        });
+        const { data: weeklySales } = useQuery({
+                queryKey: ["weeklySales"],
+                queryFn: statsService.getWeeklySales,
+        });
+        const { data: currentStock } = useQuery({
+                queryKey: ["currentStock"],
+                queryFn: statsService.getCurrentStock,
+        });
+        const { data: monthlySales } = useQuery({
+                queryKey: ["monthlySales"],
+                queryFn: statsService.getMonthlySales,
+        });
+        const { data: bestSellers } = useQuery({
+                queryKey: ["bestSellersLastEvent"],
+                queryFn: statsService.getBestSellersLastEvent,
+        });
 
 	return (
 		<div className="p-2">
@@ -74,29 +86,29 @@ function Analysis() {
 					/>
 				</Col>
 				<Col lg={6} md={12} span={24}>
-					<AnalysisCard
-						cover={glass_buy}
-						title={
-							yearlySales !== undefined
-								? `${yearlySales.toLocaleString("fr-FR")} €`
-								: "--"
-						}
-						subtitle="Stock Actuel"
-						style={{
-							color: themeVars.colors.palette.warning.dark,
-							backgroundColor: `rgba(${themeVars.colors.palette.warning.defaultChannel}, .2)`,
-						}}
-					/>
-				</Col>
-				<Col lg={6} md={12} span={24}>
-					<AnalysisCard
-						cover={glass_message}
-						title={
-							weeklySales !== undefined
-								? `${weeklySales.toLocaleString("fr-FR")} €`
-								: "--"
-						}
-						subtitle="Ventes ce mois"
+                                        <AnalysisCard
+                                                cover={glass_buy}
+                                                title={
+                                                        currentStock !== undefined
+                                                                ? currentStock.toLocaleString("fr-FR")
+                                                                : "--"
+                                                }
+                                                subtitle="Stock Actuel"
+                                                style={{
+                                                        color: themeVars.colors.palette.warning.dark,
+                                                        backgroundColor: `rgba(${themeVars.colors.palette.warning.defaultChannel}, .2)`,
+                                                }}
+                                        />
+                                </Col>
+                                <Col lg={6} md={12} span={24}>
+                                        <AnalysisCard
+                                                cover={glass_message}
+                                                title={
+                                                        monthlySales !== undefined
+                                                                ? `${monthlySales.toLocaleString("fr-FR")} €`
+                                                                : "--"
+                                                }
+                                                subtitle="Ventes ce mois"
 						style={{
 							color: themeVars.colors.palette.error.dark,
 							backgroundColor: `rgba(${themeVars.colors.palette.error.defaultChannel}, .2)`,
@@ -119,11 +131,14 @@ function Analysis() {
 			</Row>
 
 			<Row gutter={[16, 16]} className="mt-8" justify="center">
-				<Col span={24} lg={12} xl={16}>
-					<Card title="Best-sellers de la derniére convention">
-						<ChartBar />
-					</Card>
-				</Col>
+                                <Col span={24} lg={12} xl={16}>
+                                        <Card title="Best-sellers de la derniére convention">
+                                                <ChartBar
+                                                        categories={bestSellers?.map((b) => b.name) || []}
+                                                        data={bestSellers?.map((b) => b.quantity) || []}
+                                                />
+                                        </Card>
+                                </Col>
 				<Col span={24} lg={12} xl={8}>
 					<Card title="Manga 2025">
 						<ChartPie />


### PR DESCRIPTION
## Summary
- add monthly sales and stock stats endpoints
- compute best sellers for the latest event
- expose new stats methods in API client
- update analysis page to use the new endpoints
- make chart components accept dynamic data

## Testing
- `./backend/mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm run build` in `frontend` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68494a134da08326acd846f183858fcd