### PR TITLE
Connect stock page to API

### DIFF
--- a/frontend/src/api/services/licenseService.ts
+++ b/frontend/src/api/services/licenseService.ts
@@ -1,0 +1,15 @@
+import apiClient from "../apiClient";
+
+export interface License {
+	id: number;
+	name: string;
+}
+
+const getLicenses = () => apiClient.get<License[]>({ url: "/api/licenses" });
+
+const addLicense = (name: string) => apiClient.post<void>({ url: "/api/addLicense", data: { name } });
+
+export default {
+	getLicenses,
+	addLicense,
+};

--- a/frontend/src/api/services/productService.ts
+++ b/frontend/src/api/services/productService.ts
@@ -1,14 +1,23 @@
 import apiClient from "../apiClient";
 
-export enum ProductApi {
-	Products = "/produits",
-}
-
 export interface Product {
-	id_produit: number;
-	modele: string;
+	id: number;
+	model: string;
+	size?: string;
+	quantity: number;
+	stockMinimum: number;
 }
 
-const getProducts = () => apiClient.get<Product[]>({ url: ProductApi.Products });
+const getProducts = (licenseId: number) => apiClient.get<Product[]>({ url: `/api/products/${licenseId}` });
 
-export default { getProducts };
+const addProduct = (data: {
+	licenseId: number;
+	model: string;
+	quantity: number;
+	stockMinimum: number;
+}) => apiClient.post<void>({ url: "/api/addProduct", data });
+
+export default {
+	getProducts,
+	addProduct,
+};

--- a/frontend/src/pages/management/system/permission/index.tsx
+++ b/frontend/src/pages/management/system/permission/index.tsx
@@ -1,18 +1,11 @@
-import { useState } from "react";
-import {
-	Button,
-	Card,
-	Dropdown,
-	Menu,
-	Popconfirm,
-	Tag,
-	InputNumber,
-	Table,
-} from "antd";
+import { useState, useEffect } from "react";
+import { Button, Card, Dropdown, Menu, Popconfirm, Tag, InputNumber, Table } from "antd";
 import type { ColumnsType } from "antd/es/table";
 
 import { IconButton, Iconify } from "@/components/icon";
-import { type License, type Model, STOCK_DATA } from "@/_mock/stock";
+import type { License, Model } from "@/_mock/stock";
+import licenseService from "@/api/services/licenseService";
+import productService from "@/api/services/productService";
 import ModelModal, { type ModelModalProps } from "./model-modal";
 import LicenseModal, { type LicenseModalProps } from "./license-modal";
 
@@ -21,47 +14,82 @@ interface ModelRow extends Model {
 }
 
 export default function StockPage() {
-	const [licenses, setLicenses] = useState<License[]>(STOCK_DATA);
-	const [modelModalProps, setModelModalProps] = useState<ModelModalProps>({
-		licenses,
-		formValue: {},
-		title: "New Model",
-		show: false,
-		onOk: (data) => {
-			const { licenseId, ...rest } = data;
-			if (!licenseId) return;
+	const [licenses, setLicenses] = useState<License[]>([]);
+
+	const fetchLicenses = async () => {
+		try {
+			const data = await licenseService.getLicenses();
+			setLicenses(data.map((l) => ({ id: String(l.id), name: l.name, models: [] })));
+		} catch (e) {
+			alert("Failed to load licenses");
+		}
+	};
+
+	const loadProducts = async (licenseId: string) => {
+		try {
+			const products = await productService.getProducts(Number(licenseId));
 			setLicenses((prev) =>
 				prev.map((l) =>
 					l.id === licenseId
 						? {
 								...l,
-								models: [
-									...l.models,
-									{ id: Date.now().toString(), ...rest } as Model,
-								],
+								models: products.map((p) => ({
+									id: String(p.id),
+									name: p.model,
+									quantity: p.quantity,
+									minStock: p.stockMinimum,
+								})),
 							}
 						: l,
 				),
 			);
-			setModelModalProps((p) => ({ ...p, show: false }));
+		} catch (e) {
+			alert("Failed to load products");
+		}
+	};
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount
+	useEffect(() => {
+		fetchLicenses();
+	}, []);
+	const [modelModalProps, setModelModalProps] = useState<ModelModalProps>({
+		licenses,
+		formValue: {},
+		title: "New Model",
+		show: false,
+		onOk: async (data) => {
+			const { licenseId, name, quantity, minStock } = data;
+			if (!licenseId) return;
+			try {
+				await productService.addProduct({
+					licenseId: Number(licenseId),
+					model: name ?? "",
+					quantity: quantity ?? 0,
+					stockMinimum: minStock ?? 0,
+				});
+				await loadProducts(licenseId);
+				setModelModalProps((p) => ({ ...p, show: false }));
+			} catch (e) {
+				alert("Failed to add product");
+			}
 		},
 		onCancel: () => setModelModalProps((p) => ({ ...p, show: false })),
 	});
-	const [licenseModalProps, setLicenseModalProps] = useState<LicenseModalProps>(
-		{
-			formValue: {},
-			title: "New Licence",
-			show: false,
-			onOk: (data) => {
-				setLicenses((prev) => [
-					...prev,
-					{ id: Date.now().toString(), name: data.name ?? "", models: [] },
-				]);
+	const [licenseModalProps, setLicenseModalProps] = useState<LicenseModalProps>({
+		formValue: {},
+		title: "New Licence",
+		show: false,
+		onOk: async (data) => {
+			try {
+				await licenseService.addLicense(data.name ?? "");
+				await fetchLicenses();
 				setLicenseModalProps((p) => ({ ...p, show: false }));
-			},
-			onCancel: () => setLicenseModalProps((p) => ({ ...p, show: false })),
+			} catch (e) {
+				alert("Failed to add license");
+			}
 		},
-	);
+		onCancel: () => setLicenseModalProps((p) => ({ ...p, show: false })),
+	});
 
 	const openNewMenu = (
 		<Menu
@@ -73,61 +101,48 @@ export default function StockPage() {
 				if (info.key === "lic") {
 					setLicenseModalProps((p) => ({ ...p, show: true }));
 				} else {
-					setModelModalProps((p) => ({ ...p, show: true }));
+					setModelModalProps((p) => ({ ...p, show: true, licenses }));
 				}
 			}}
 		/>
 	);
 
-
 	const deleteModel = (licenseId: string, modelId: string) => {
 		setLicenses((prev) =>
-			prev.map((l) =>
-				l.id === licenseId
-					? { ...l, models: l.models.filter((m) => m.id !== modelId) }
-					: l,
-			),
+			prev.map((l) => (l.id === licenseId ? { ...l, models: l.models.filter((m) => m.id !== modelId) } : l)),
 		);
 	};
 
-	const updateModel = (
-		licenseId: string,
-		modelId: string,
-		data: Partial<Model>,
-	) => {
+	const updateModel = (licenseId: string, modelId: string, data: Partial<Model>) => {
 		setLicenses((prev) =>
 			prev.map((l) =>
 				l.id === licenseId
 					? {
 							...l,
-							models: l.models.map((m) =>
-								m.id === modelId ? { ...m, ...data } : m,
-							),
+							models: l.models.map((m) => (m.id === modelId ? { ...m, ...data } : m)),
 						}
 					: l,
 			),
 		);
 	};
 
-        const modelColumns: ColumnsType<ModelRow> = [
-                {
-                        title: "Name",
-                        dataIndex: "name",
-                },
-                {
-                        title: "Quantité",
-                        dataIndex: "quantity",
-                },
-                {
-                        title: "Stock Minimum",
-                        dataIndex: "minStock",
+	const modelColumns: ColumnsType<ModelRow> = [
+		{
+			title: "Name",
+			dataIndex: "name",
+		},
+		{
+			title: "Quantité",
+			dataIndex: "quantity",
+		},
+		{
+			title: "Stock Minimum",
+			dataIndex: "minStock",
 			render: (min, record) => (
 				<InputNumber
 					min={0}
 					value={min}
-					onChange={(v) =>
-						updateModel(record.licenseId, record.id, { minStock: Number(v) })
-					}
+					onChange={(v) => updateModel(record.licenseId, record.id, { minStock: Number(v) })}
 				/>
 			),
 		},
@@ -147,12 +162,12 @@ export default function StockPage() {
 				return <Tag color={color}>{text}</Tag>;
 			},
 		},
-                {
-                        title: "Action",
-                        key: "action",
-                        align: "center",
-                        render: (_, record) => (
-                                <div className="flex justify-end text-gray">
+		{
+			title: "Action",
+			key: "action",
+			align: "center",
+			render: (_, record) => (
+				<div className="flex justify-end text-gray">
 					<IconButton
 						onClick={() =>
 							setModelModalProps({
@@ -181,11 +196,7 @@ export default function StockPage() {
 						onConfirm={() => deleteModel(record.licenseId, record.id)}
 					>
 						<IconButton>
-							<Iconify
-								icon="mingcute:delete-2-fill"
-								size={18}
-								className="text-error"
-							/>
+							<Iconify icon="mingcute:delete-2-fill" size={18} className="text-error" />
 						</IconButton>
 					</Popconfirm>
 				</div>
@@ -219,14 +230,10 @@ export default function StockPage() {
 							...m,
 							licenseId: record.id,
 						}));
-						return (
-							<Table
-								rowKey="id"
-								columns={modelColumns}
-								dataSource={data}
-								pagination={false}
-							/>
-						);
+						return <Table rowKey="id" columns={modelColumns} dataSource={data} pagination={false} />;
+					},
+					onExpand: (exp, record) => {
+						if (exp) loadProducts(record.id);
 					},
 				}}
 				dataSource={licenses}


### PR DESCRIPTION
## Summary
- connect license/product management to backend
- fetch licenses and products from REST API
- add new API services for licenses and products
- hook up forms to create licenses and products via API

## Testing
- `npx -y @biomejs/biome format --write src/api/services/licenseService.ts src/api/services/productService.ts src/pages/management/system/permission/index.tsx`
- `npx -y @biomejs/biome lint --no-errors-on-unmatched src/api/services/licenseService.ts src/api/services/productService.ts src/pages/management/system/permission/index.tsx`
- `npx -y tsc --noEmit` *(fails: Cannot find module and JSX runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ab86c2bc083268c9786d221d0e4c9