### PR TITLE
Fix build errors and add missing types

### DIFF
--- a/frontend/src/api/services/statsService.ts
+++ b/frontend/src/api/services/statsService.ts
@@ -1,4 +1,5 @@
 import apiClient from "../apiClient";
+import type { BestSellerDTO, LicenseStatDTO } from "#/stats";
 
 export enum StatsApi {
 	WeeklySales = "/stats/getWeeklySales",

--- a/frontend/src/pages/components/chart/index.tsx
+++ b/frontend/src/pages/components/chart/index.tsx
@@ -14,10 +14,15 @@ import ChartRadar from "./view/chart-radar";
 import ChartRadial from "./view/chart-radial";
 
 export default function ChartPage() {
-	return (
-		<>
-			<Typography.Link
-				href="https://apexcharts.com"
+        const barSeries = [40, 60, 80, 20];
+        const barCategories = ["A", "B", "C", "D"];
+        const pieSeries = [44, 55, 13, 43];
+        const pieLabels = ["Apple", "Mango", "Orange", "Watermelon"];
+
+        return (
+                <>
+                        <Typography.Link
+                                href="https://apexcharts.com"
 				style={{ color: themeVars.colors.palette.primary.default }}
 				className="mb-4 block"
 			>
@@ -58,22 +63,22 @@ export default function ChartPage() {
 					</Card>
 				</Col>
 
-				<Col span={23} lg={12}>
-					<Card title="Bar">
-						<ChartBar />
-					</Card>
-				</Col>
+                                <Col span={23} lg={12}>
+                                        <Card title="Bar">
+                                                <ChartBar series={barSeries} categories={barCategories} />
+                                        </Card>
+                                </Col>
 				<Col span={23} lg={12}>
 					<Card title="Column Mixed">
 						<ChartMixed />
 					</Card>
 				</Col>
 
-				<Col span={24} lg={12}>
-					<Card title="Pie">
-						<ChartPie />
-					</Card>
-				</Col>
+                                <Col span={24} lg={12}>
+                                        <Card title="Pie">
+                                                <ChartPie series={pieSeries} labels={pieLabels} />
+                                        </Card>
+                                </Col>
 				<Col span={23} lg={12}>
 					<Card title="Donut">
 						<ChartDonut />

--- a/frontend/src/pages/management/caisse/index.tsx
+++ b/frontend/src/pages/management/caisse/index.tsx
@@ -26,13 +26,13 @@ const PRICE_MAP: Record<string, number> = {
 };
 
 const LOCAL_PRODUCTS: Product[] = [
-       { id_produit: 0, modele: "Dressrossa" },
+       { id: 0, model: "Dressrossa", quantity: 0, stockMinimum: 0 },
 ];
 
 export default function CaissePage() {
         const { data: products } = useQuery({
-                queryKey: ["products"],
-                queryFn: productService.getProducts,
+                queryKey: ["products", 0],
+                queryFn: ({ queryKey }) => productService.getProducts(queryKey[1] as number),
         });
 
        const productList = Array.isArray(products) && products.length > 0 ? products : LOCAL_PRODUCTS;
@@ -81,11 +81,11 @@ export default function CaissePage() {
                 },
         ];
 
-        const onAddItem = (product: Product, variant: string) => {
-                addItem({
-                        idProduit: product.id_produit,
-                        name: `${product.modele} - ${variant}`,
-                        variante: variant,
+const onAddItem = (product: Product, variant: string) => {
+        addItem({
+                idProduit: product.id,
+                name: `${product.model} - ${variant}`,
+                variante: variant,
                         unitPrice: PRICE_MAP[variant],
                         quantity: 1,
                 });
@@ -153,13 +153,13 @@ export default function CaissePage() {
                                         <Input placeholder="Rechercher" value={search} onChange={(e) => setSearch(e.target.value)} />
                                         {productList
                                                 .filter((p) =>
-                                                        p.modele
+                                                        p.model
                                                                 .toLowerCase()
                                                                 .includes(search.toLowerCase()),
                                                 )
                                                 .map((p) => (
-                                                <Card key={p.id_produit} className="w-full">
-                                                        <Typography.Text>{p.modele}</Typography.Text>
+                                                <Card key={p.id} className="w-full">
+                                                        <Typography.Text>{p.model}</Typography.Text>
                                                         <div className="mt-2 flex gap-2 flex-wrap">
                                                                 {VARIANTS.map((v) => (
                                                                         <Button key={v} onClick={() => onAddItem(p, v)}>

--- a/frontend/types/stats.ts
+++ b/frontend/types/stats.ts
@@ -1,0 +1,12 @@
+export interface BestSellerDTO {
+  productName: string;
+  licenseName: string;
+  quantitySold: number;
+  total: number;
+}
+
+export interface LicenseStatDTO {
+  licenseName: string;
+  count: number;
+  percentage: number;
+}


### PR DESCRIPTION
## Summary
- fix Chart demo page props
- fix caisse page product field names
- add best seller and license stat interfaces
- hook statsService to new types

## Testing
- `pnpm run build`
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684abdb07db0832687bddb481e457a60