### PR TITLE
Fix API endpoints and dropdown

### DIFF
--- a/frontend/src/api/services/licenseService.ts
+++ b/frontend/src/api/services/licenseService.ts
@@ -5,9 +5,10 @@ export interface License {
 	name: string;
 }
 
-const getLicenses = () => apiClient.get<License[]>({ url: "/api/licenses" });
+const getLicenses = () => apiClient.get<License[]>({ url: "/licences" });
 
-const addLicense = (name: string) => apiClient.post<void>({ url: "/api/addLicense", data: { name } });
+const addLicense = (name: string) =>
+        apiClient.post<void>({ url: "/licences", data: { name } });
 
 export default {
 	getLicenses,

--- a/frontend/src/api/services/productService.ts
+++ b/frontend/src/api/services/productService.ts
@@ -8,14 +8,15 @@ export interface Product {
 	stockMinimum: number;
 }
 
-const getProducts = (licenseId: number) => apiClient.get<Product[]>({ url: `/api/products/${licenseId}` });
+const getProducts = (licenseId: number) =>
+        apiClient.get<Product[]>({ url: `/produits/${licenseId}` });
 
 const addProduct = (data: {
 	licenseId: number;
 	model: string;
 	quantity: number;
 	stockMinimum: number;
-}) => apiClient.post<void>({ url: "/api/addProduct", data });
+}) => apiClient.post<void>({ url: "/produits", data });
 
 export default {
 	getProducts,

--- a/frontend/src/pages/management/system/permission/index.tsx
+++ b/frontend/src/pages/management/system/permission/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Button, Card, Dropdown, Menu, Popconfirm, Tag, InputNumber, Table } from "antd";
+import { Button, Card, Dropdown, Popconfirm, Tag, InputNumber, Table } from "antd";
 import type { ColumnsType } from "antd/es/table";
 
 import { IconButton, Iconify } from "@/components/icon";
@@ -91,21 +91,19 @@ export default function StockPage() {
 		onCancel: () => setLicenseModalProps((p) => ({ ...p, show: false })),
 	});
 
-	const openNewMenu = (
-		<Menu
-			items={[
-				{ key: "lic", label: "Créer une nouvelle licence" },
-				{ key: "model", label: "Ajouter un modèle" },
-			]}
-			onClick={(info) => {
-				if (info.key === "lic") {
-					setLicenseModalProps((p) => ({ ...p, show: true }));
-				} else {
-					setModelModalProps((p) => ({ ...p, show: true, licenses }));
-				}
-			}}
-		/>
-	);
+        const openNewMenu = {
+                items: [
+                        { key: "lic", label: "Créer une nouvelle licence" },
+                        { key: "model", label: "Ajouter un modèle" },
+                ],
+                onClick: (info: { key: string }) => {
+                        if (info.key === "lic") {
+                                setLicenseModalProps((p) => ({ ...p, show: true }));
+                        } else {
+                                setModelModalProps((p) => ({ ...p, show: true, licenses }));
+                        }
+                },
+        };
 
 	const deleteModel = (licenseId: string, modelId: string) => {
 		setLicenses((prev) =>
@@ -216,9 +214,9 @@ export default function StockPage() {
 		<Card
 			title="Stock"
 			extra={
-				<Dropdown overlay={openNewMenu} trigger={["click"]}>
-					<Button type="primary">New</Button>
-				</Dropdown>
+                                <Dropdown menu={openNewMenu} trigger={["click"]}>
+                                        <Button type="primary">New</Button>
+                                </Dropdown>
 			}
 		>
 			<Table


### PR DESCRIPTION
## Summary
- fix license and product endpoints so they match backend routes
- update dropdown to new antd `menu` API

## Testing
- `npm install --legacy-peer-deps` *(fails: unsupported engine)*
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ac069dd788326b094ee47299d5f41