### PR TITLE
Fix stock page product fetch

### DIFF
--- a/frontend/src/api/services/productService.ts
+++ b/frontend/src/api/services/productService.ts
@@ -9,8 +9,12 @@ export interface Product {
 }
 
 // Endpoints shouldn't start with /api because axios baseURL already uses it.
-const getProducts = (licenseId: number) =>
-    apiClient.get<Product[]>({ url: `/products/${licenseId}` });
+// licenseId is optional; if undefined, the backend should return all products
+// instead of filtering by license. This prevents URLs like `/products/[object Object]`.
+const getProducts = (licenseId?: number) => {
+       const url = licenseId !== undefined ? `/products/${licenseId}` : "/products";
+       return apiClient.get<Product[]>({ url });
+};
 
 const addProduct = (data: {
 	licenseId: number;

--- a/frontend/src/pages/management/caisse/index.tsx
+++ b/frontend/src/pages/management/caisse/index.tsx
@@ -30,10 +30,10 @@ const LOCAL_PRODUCTS: Product[] = [
 ];
 
 export default function CaissePage() {
-        const { data: products } = useQuery({
-                queryKey: ["products"],
-                queryFn: productService.getProducts,
-        });
+       const { data: products } = useQuery({
+               queryKey: ["products"],
+               queryFn: () => productService.getProducts(),
+       });
 
        const productList = Array.isArray(products) && products.length > 0 ? products : LOCAL_PRODUCTS;
 


### PR DESCRIPTION
## Summary
- make `licenseId` optional in `productService.getProducts`
- call `getProducts` with no arg when listing all products

## Testing
- `npx biome lint src/api/services/productService.ts src/pages/management/caisse/index.tsx`
- `npx tsc --noEmit` *(fails: Could not find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684aedf7ba308326a0d28919255c8694