### PR TITLE
Update home page and header

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,4 +1,4 @@
 VITE_APP_BASE_API=/api
-VITE_APP_HOMEPAGE=/dashboard/workbench
+VITE_APP_HOMEPAGE=/dashboard/analysis
 VITE_APP_BASE_PATH=/
 VITE_APP_ROUTER_MODE=module

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,3 +1,3 @@
 VITE_APP_BASE_API=/api
-VITE_APP_HOMEPAGE=/dashboard/workbench
+VITE_APP_HOMEPAGE=/dashboard/analysis
 VITE_APP_BASE_PATH=/

--- a/frontend/src/layouts/dashboard/header.tsx
+++ b/frontend/src/layouts/dashboard/header.tsx
@@ -1,15 +1,13 @@
 import { Drawer } from "antd";
 import { type CSSProperties, useState } from "react";
 
-import { IconButton, Iconify, SvgIcon } from "@/components/icon";
-import LocalePicker from "@/components/locale-picker";
+import { IconButton, SvgIcon } from "@/components/icon";
 import Logo from "@/components/logo";
 import { useSettings } from "@/store/settingStore";
 
 import AccountDropdown from "../components/account-dropdown";
 import BreadCrumb from "../components/bread-crumb";
 import NoticeButton from "../components/notice";
-import SearchBar from "../components/search-bar";
 import SettingButton from "../components/setting-button";
 
 import { themeVars } from "@/theme/theme.css";
@@ -35,7 +33,11 @@ export default function Header() {
 	return (
 		<>
 			<header
-				className={cn(themeLayout === ThemeLayout.Horizontal ? "relative" : "sticky top-0 right-0 left-auto")}
+				className={cn(
+					themeLayout === ThemeLayout.Horizontal
+						? "relative"
+						: "sticky top-0 right-0 left-auto",
+				)}
 				style={headerStyle}
 			>
 				<div
@@ -47,24 +49,21 @@ export default function Header() {
 				>
 					<div className="flex items-baseline">
 						{themeLayout !== ThemeLayout.Horizontal ? (
-							<IconButton onClick={() => setDrawerOpen(true)} className="h-10 w-10 md:hidden">
+							<IconButton
+								onClick={() => setDrawerOpen(true)}
+								className="h-10 w-10 md:hidden"
+							>
 								<SvgIcon icon="ic-menu" size="24" />
 							</IconButton>
 						) : (
 							<Logo />
 						)}
-						<div className="ml-4 hidden md:block">{breadCrumb ? <BreadCrumb /> : null}</div>
+						<div className="ml-4 hidden md:block">
+							{breadCrumb ? <BreadCrumb /> : null}
+						</div>
 					</div>
 
 					<div className="flex">
-						<SearchBar />
-						<LocalePicker />
-						<IconButton onClick={() => window.open("https://github.com/d3george/slash-admin")}>
-							<Iconify icon="mdi:github" size={24} />
-						</IconButton>
-						<IconButton onClick={() => window.open("https://discord.gg/fXemAXVNDa")}>
-							<Iconify icon="carbon:logo-discord" size={24} />
-						</IconButton>
 						<NoticeButton />
 						<SettingButton />
 						<AccountDropdown />
@@ -76,7 +75,9 @@ export default function Header() {
 				onClose={() => setDrawerOpen(false)}
 				open={drawerOpen}
 				closeIcon={false}
-				width={themeLayout === ThemeLayout.Mini ? NAV_COLLAPSED_WIDTH : NAV_WIDTH}
+				width={
+					themeLayout === ThemeLayout.Mini ? NAV_COLLAPSED_WIDTH : NAV_WIDTH
+				}
 			>
 				<NavVertical closeSideBarDrawer={() => setDrawerOpen(false)} />
 			</Drawer>

--- a/frontend/src/router/routes/modules/dashboard.tsx
+++ b/frontend/src/router/routes/modules/dashboard.tsx
@@ -26,10 +26,10 @@ const dashboard: AppRouteObject = {
 		hideMenu: true,
 	},
 	children: [
-		{
-			index: true,
-			element: <Navigate to="workbench" replace />,
-		},
+                {
+                        index: true,
+                        element: <Navigate to="analysis" replace />,
+                },
 		{
 			path: "workbench",
 			element: <HomePage />,


### PR DESCRIPTION
## Summary
- default dashboard route now goes to the analysis page
- update environment variables to use /dashboard/analysis as homepage
- remove search, locale switch and external links from dashboard header

## Testing
- `npx @biomejs/biome lint frontend/src/layouts/dashboard/header.tsx`


------
https://chatgpt.com/codex/tasks/task_e_684b3215e3388326afefee59e0cbeb10