### PR TITLE
Add simple Spring Security login

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,15 @@ This repository contains a Spring Boot backend and a React frontend. The project
    ```bash
    cd frontend
    npm install
-   npm run dev
-   ```
+  npm run dev
+  ```
+
+## Default Credentials
+
+Spring Security protects backend routes. Use the following credentials to sign in at `/login`:
+
+- **Username**: `admin`
+- **Password**: `demo1234`
 
 ## Deploying on Railway
 

--- a/backend/src/main/java/com/wooden/project/config/SecurityConfig.java
+++ b/backend/src/main/java/com/wooden/project/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.wooden.project.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.Customizer;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().authenticated()
+            )
+            .formLogin(Customizer.withDefaults())
+            .httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User
+            .withUsername("admin")
+            .password(passwordEncoder().encode("demo1234"))
+            .authorities("FULL")
+            .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,6 +10,5 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.open-in-view=true
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 


### PR DESCRIPTION
## Summary
- enable Spring Security with an in-memory user
- remove unused `/auth/signin` controller
- document default credentials in README

Default credentials are `admin` / `demo1234`.

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b3e630b5483269359529835626b15