### PR TITLE
Integrate product search API

### DIFF
--- a/backend/src/main/java/com/wooden/project/controller/InventoryController.java
+++ b/backend/src/main/java/com/wooden/project/controller/InventoryController.java
@@ -70,6 +70,27 @@ public class InventoryController {
         return Result.success(products);
     }
 
+    @GetMapping("/products/search")
+    public Result<List<ProductDTO>> searchProducts(@RequestParam("q") String query) {
+        List<Stock> stocks = stockRepository.searchByProductName(query);
+        List<ProductDTO> products = stocks.stream()
+                .map(s -> {
+                    Double avg = panierItemRepository.getAveragePriceByProductId(s.getId_produit().getId_produit());
+                    double value = (avg != null ? avg : 0) * s.getQuantite();
+                    return new ProductDTO(
+                            s.getId_produit().getLicence_id().getId_license(),
+                            s.getId_produit().getId_produit(),
+                            s.getId_produit().getModele(),
+                            s.getId_produit().getTaille().name(),
+                            s.getQuantite(),
+                            s.getStockMinimum() != null ? s.getStockMinimum() : 0,
+                            value
+                    );
+                })
+                .collect(Collectors.toList());
+        return Result.success(products);
+    }
+
     public static class AddProductRequest {
         public Long licenseId;
         public String model;

--- a/backend/src/main/java/com/wooden/project/repository/StockRepository.java
+++ b/backend/src/main/java/com/wooden/project/repository/StockRepository.java
@@ -11,4 +11,10 @@ import java.util.List;
 public interface StockRepository extends JpaRepository<Stock, Long> {
     @Query("SELECT s FROM Stock s WHERE s.id_produit.licence_id.id_license = :licenseId")
     List<Stock> findByLicenseId(Long licenseId);
+
+    /**
+     * Search stocks by product model. Case-insensitive.
+     */
+    @Query("SELECT s FROM Stock s WHERE LOWER(s.id_produit.modele) LIKE LOWER(CONCAT('%', :query, '%'))")
+    List<Stock> searchByProductName(String query);
 }

--- a/frontend/src/api/services/productService.ts
+++ b/frontend/src/api/services/productService.ts
@@ -23,13 +23,17 @@ const getProducts = (licenseId?: number) => {
 };
 
 const addProduct = (data: {
-	licenseId: number;
-	model: string;
-	quantity: number;
-	stockMinimum: number;
+        licenseId: number;
+        model: string;
+        quantity: number;
+        stockMinimum: number;
 }) => apiClient.post<void>({ url: "/addProduct", data });
 
+const searchProducts = (query: string) =>
+        apiClient.get<Product[]>({ url: "/products/search", params: { q: query } });
+
 export default {
-	getProducts,
-	addProduct,
+        getProducts,
+        addProduct,
+        searchProducts,
 };

--- a/frontend/src/api/services/salesService.ts
+++ b/frontend/src/api/services/salesService.ts
@@ -18,6 +18,10 @@ class SalesService {
     getLatestSales() {
         return apiClient.get<SalesData[]>({ url: '/paniers/latest-sales' });
     }
+
+    createSale(data: unknown) {
+        return apiClient.post<void>({ url: '/paniers', data });
+    }
 }
 
 const salesService = new SalesService();

--- a/frontend/src/api/services/statsService.ts
+++ b/frontend/src/api/services/statsService.ts
@@ -1,4 +1,5 @@
 import apiClient from "../apiClient";
+import type { BestSellerDTO, LicenseStatDTO } from "#/api";
 
 export enum StatsApi {
 	WeeklySales = "/stats/getWeeklySales",

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -1,5 +1,18 @@
 export interface Result<T = any> {
-	status: number;
-	message: string;
-	data?: T;
+        status: number;
+        message: string;
+        data?: T;
+}
+
+export interface BestSellerDTO {
+        productName: string;
+        licenseName: string;
+        quantitySold: number;
+        total: number;
+}
+
+export interface LicenseStatDTO {
+        licenseName: string;
+        count: number;
+        percentage: number;
 }


### PR DESCRIPTION
## Summary
- backend: add search method in StockRepository
- backend: expose `/products/search` endpoint
- frontend: add `searchProducts` API call
- connect caisse page search to backend
- declare DTO types for stats service

## Testing
- `npx -y @biomejs/biome lint frontend/src/api/services/productService.ts frontend/src/api/services/statsService.ts frontend/src/pages/management/caisse/index.tsx types/api.ts`
- `npx -y tsc --noEmit` *(fails: Chart components missing props)*

------
https://chatgpt.com/codex/tasks/task_e_684b3afdd17c8326801129ebf374baa0