### PR TITLE
Implement weekly average basket chart

### DIFF
--- a/backend/src/main/java/com/wooden/project/controller/StatsController.java
+++ b/backend/src/main/java/com/wooden/project/controller/StatsController.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import com.wooden.project.dto.BestSellerDTO;
 import com.wooden.project.dto.LicenseStatDTO;
+import com.wooden.project.dto.WeeklyAverageDTO;
 
 @RestController
 @RequestMapping("/api/stats")
@@ -64,6 +65,11 @@ public class StatsController {
     @GetMapping("/getLast20Sales")
     public Object getLast20Sales() {
         return statisticsService.getLast20Sales();
+    }
+
+    @GetMapping("/getAverageBasketByWeek")
+    public List<WeeklyAverageDTO> getAverageBasketByWeek() {
+        return statisticsService.getAverageBasketByWeek(20);
     }
     
     @GetMapping("/getBestSellersLastEvent")

--- a/backend/src/main/java/com/wooden/project/dto/WeeklyAverageDTO.java
+++ b/backend/src/main/java/com/wooden/project/dto/WeeklyAverageDTO.java
@@ -1,0 +1,27 @@
+package com.wooden.project.dto;
+
+public class WeeklyAverageDTO {
+    private int week;
+    private double average;
+
+    public WeeklyAverageDTO(int week, double average) {
+        this.week = week;
+        this.average = average;
+    }
+
+    public int getWeek() {
+        return week;
+    }
+
+    public void setWeek(int week) {
+        this.week = week;
+    }
+
+    public double getAverage() {
+        return average;
+    }
+
+    public void setAverage(double average) {
+        this.average = average;
+    }
+}

--- a/backend/src/main/java/com/wooden/project/repository/PanierRepo.java
+++ b/backend/src/main/java/com/wooden/project/repository/PanierRepo.java
@@ -44,4 +44,7 @@ public interface PanierRepo extends JpaRepository<Panier, Long> {
            "FROM PanierItem pi JOIN pi.produit.licence_id l WHERE YEAR(pi.panier.dateAjout) = YEAR(CURRENT_DATE) " +
            "GROUP BY l.name_license")
     List<Map<String, Object>> findLicenseSalesStats();
+
+    @Query(value = "SELECT WEEK(p.dateAjout, 1) AS week, AVG(p.prix_panier) AS average FROM panier p WHERE p.dateAjout >= :startDate GROUP BY week ORDER BY week", nativeQuery = true)
+    List<Map<String, Object>> findWeeklyAverage(@Param("startDate") Date startDate);
 }

--- a/backend/src/main/java/com/wooden/project/service/StatisticsService.java
+++ b/backend/src/main/java/com/wooden/project/service/StatisticsService.java
@@ -2,6 +2,7 @@ package com.wooden.project.service;
 
 import com.wooden.project.dto.BestSellerDTO;
 import com.wooden.project.dto.LicenseStatDTO;
+import com.wooden.project.dto.WeeklyAverageDTO;
 import com.wooden.project.model.Panier;
 import com.wooden.project.model.evenement;
 import com.wooden.project.repository.UserRepo;
@@ -68,6 +69,21 @@ public class StatisticsService {
 
     public List<Panier> getLast20Sales() {
         return panierRepo.findTop20ByOrderByDateAjoutDesc();
+    }
+
+    public List<WeeklyAverageDTO> getAverageBasketByWeek(int weeks) {
+        LocalDate start = LocalDate.now().minusWeeks(weeks - 1);
+        Date startDate = Date.from(start.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        List<java.util.Map<String, Object>> results = panierRepo.findWeeklyAverage(startDate);
+        List<WeeklyAverageDTO> averages = new ArrayList<>();
+
+        for (java.util.Map<String, Object> result : results) {
+            Integer week = ((Number) result.get("week")).intValue();
+            Double average = ((Number) result.get("average")).doubleValue();
+            averages.add(new WeeklyAverageDTO(week, average));
+        }
+
+        return averages;
     }
     
     public List<BestSellerDTO> getBestSellersLastEvent() {

--- a/frontend/src/api/services/statsService.ts
+++ b/frontend/src/api/services/statsService.ts
@@ -1,5 +1,5 @@
 import apiClient from "../apiClient";
-import type { BestSellerDTO, LicenseStatDTO } from "#/api";
+import type { BestSellerDTO, LicenseStatDTO, WeeklyAverageDTO } from "#/api";
 
 export enum StatsApi {
 	WeeklySales = "/stats/getWeeklySales",
@@ -11,7 +11,8 @@ export enum StatsApi {
 	TotalStockValue = "/stats/getTotalStockValue",
 	TotalStockCount = "/stats/getTotalStockCount",
 	BestSellersLastEvent = "/stats/getBestSellersLastEvent",
-	LicenseSalesStats = "/stats/getLicenseSalesStats",
+        LicenseSalesStats = "/stats/getLicenseSalesStats",
+        AverageBasketByWeek = "/stats/getAverageBasketByWeek",
 }
 
 const getWeeklySales = () =>
@@ -29,11 +30,13 @@ const getLast20Sales = () =>
 const getTotalStockValue = () =>
 	apiClient.get<number>({ url: StatsApi.TotalStockValue });
 const getTotalStockCount = () =>
-	apiClient.get<number>({ url: StatsApi.TotalStockCount });
+        apiClient.get<number>({ url: StatsApi.TotalStockCount });
 const getBestSellersLastEvent = () =>
-	apiClient.get<BestSellerDTO[]>({ url: StatsApi.BestSellersLastEvent });
+        apiClient.get<BestSellerDTO[]>({ url: StatsApi.BestSellersLastEvent });
 const getLicenseSalesStats = () =>
-	apiClient.get<LicenseStatDTO[]>({ url: StatsApi.LicenseSalesStats });
+        apiClient.get<LicenseStatDTO[]>({ url: StatsApi.LicenseSalesStats });
+const getAverageBasketByWeek = () =>
+        apiClient.get<WeeklyAverageDTO[]>({ url: StatsApi.AverageBasketByWeek });
 
 export default {
 	getWeeklySales,
@@ -44,6 +47,7 @@ export default {
 	getLast20Sales,
 	getTotalStockValue,
 	getTotalStockCount,
-	getBestSellersLastEvent,
-	getLicenseSalesStats,
+        getBestSellersLastEvent,
+        getLicenseSalesStats,
+        getAverageBasketByWeek,
 };

--- a/frontend/src/pages/components/chart/index.tsx
+++ b/frontend/src/pages/components/chart/index.tsx
@@ -30,11 +30,11 @@ export default function ChartPage() {
 						<ChartArea />
 					</Card>
 				</Col>
-				<Col span={23} lg={12}>
-					<Card title="Line">
-						<ChartLine />
-					</Card>
-				</Col>
+                                <Col span={23} lg={12}>
+                                        <Card title="Évolution du Panier moyen">
+                                                <ChartLine />
+                                        </Card>
+                                </Col>
 
 				<Col span={23} lg={12}>
 					<Card title="Column Single">

--- a/frontend/src/pages/components/chart/view/chart-line.tsx
+++ b/frontend/src/pages/components/chart/view/chart-line.tsx
@@ -1,36 +1,34 @@
 import Chart from "@/components/chart/chart";
 import useChart from "@/components/chart/useChart";
+import { useQuery } from "@tanstack/react-query";
+import statsService from "@/api/services/statsService";
 
-const series = [
-	{
-		name: "Desktops",
-		data: [10, 41, 35, 51, 49, 62, 69, 91, 148],
-	},
-];
 export default function ChartLine() {
-	const chartOptions = useChart({
-		xaxis: {
-			categories: [
-				"Jan",
-				"Feb",
-				"Mar",
-				"Apr",
-				"May",
-				"Jun",
-				"Jul",
-				"Aug",
-				"Sep",
-			],
-		},
-		tooltip: {
-			x: {
-				show: false,
-			},
-			marker: { show: false },
-		},
-	});
+        const { data } = useQuery({
+                queryKey: ["averageBasketByWeek"],
+                queryFn: statsService.getAverageBasketByWeek,
+        });
 
-	return (
-		<Chart type="line" series={series} options={chartOptions} height={320} />
-	);
+        const series = [
+                {
+                        name: "Panier moyen",
+                        data: data ? data.map((d) => d.average) : [],
+                },
+        ];
+
+        const chartOptions = useChart({
+                xaxis: {
+                        categories: data ? data.map((d) => `S${d.week}`) : [],
+                },
+                tooltip: {
+                        y: {
+                                formatter: (value: number) => `${value.toFixed(2)} €`,
+                        },
+                        marker: { show: false },
+                },
+        });
+
+        return (
+                <Chart type="line" series={series} options={chartOptions} height={320} />
+        );
 }

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -16,3 +16,8 @@ export interface LicenseStatDTO {
         count: number;
         percentage: number;
 }
+
+export interface WeeklyAverageDTO {
+        week: number;
+        average: number;
+}


### PR DESCRIPTION
## Summary
- rename line chart card to "Évolution du Panier moyen"
- fetch data for the line chart from the backend
- add API types and service function for average basket
- implement backend endpoint to compute weekly averages

## Testing
- `npx biome lint frontend/src/pages/components/chart/view/chart-line.tsx`
- `npx biome lint frontend/src/pages/components/chart/index.tsx`
- `npx biome lint frontend/src/api/services/statsService.ts`
- `npx biome lint frontend/types/api.ts`
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b59022550832683905c73cd826093