### PR TITLE
Fix duplicate product listing and add sale API

### DIFF
--- a/backend/src/main/java/com/wooden/project/controller/VenteController.java
+++ b/backend/src/main/java/com/wooden/project/controller/VenteController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/Ventes")
+@RequestMapping("/api/ventes")
 public class VenteController {
 
     private final VenteService VentesService;

--- a/backend/src/main/java/com/wooden/project/controller/VenteController.java
+++ b/backend/src/main/java/com/wooden/project/controller/VenteController.java
@@ -1,7 +1,11 @@
 package com.wooden.project.controller;
 
+import com.wooden.project.model.Panier;
 import com.wooden.project.model.Ventes;
+import com.wooden.project.service.PanierService;
 import com.wooden.project.service.VenteService;
+
+import java.util.Date;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,8 +17,10 @@ import java.util.List;
 public class VenteController {
 
     private final VenteService VentesService;
+    private final PanierService panierService;
 
-    public VenteController(VenteService ventesService) {
+    public VenteController(VenteService ventesService, PanierService panierService) {
+        this.panierService = panierService;
         VentesService = ventesService;
     }
 
@@ -26,5 +32,14 @@ public class VenteController {
     @PostMapping
     public Ventes createVentes(@RequestBody Ventes Ventes) {
         return VentesService.save(Ventes);
+    }
+
+    @PostMapping("/register")
+    public Panier registerSale(@RequestBody Panier panier) {
+        panier.setMode_paiement("espece");
+        if (panier.getDateAjout() == null) {
+            panier.setDateAjout(new Date());
+        }
+        return panierService.createPanierWithItems(panier);
     }
 }

--- a/frontend/src/api/services/salesService.ts
+++ b/frontend/src/api/services/salesService.ts
@@ -20,7 +20,7 @@ class SalesService {
     }
 
     createSale(data: unknown) {
-        return apiClient.post<void>({ url: '/Ventes/register', data });
+        return apiClient.post<void>({ url: '/ventes/register', data });
     }
 }
 

--- a/frontend/src/api/services/salesService.ts
+++ b/frontend/src/api/services/salesService.ts
@@ -20,7 +20,7 @@ class SalesService {
     }
 
     createSale(data: unknown) {
-        return apiClient.post<void>({ url: '/paniers', data });
+        return apiClient.post<void>({ url: '/Ventes/register', data });
     }
 }
 

--- a/frontend/src/pages/management/caisse/index.tsx
+++ b/frontend/src/pages/management/caisse/index.tsx
@@ -59,6 +59,10 @@ export default function CaissePage() {
                        ? products
                        : LOCAL_PRODUCTS;
 
+       const uniqueProducts = productList.filter(
+               (p, index, arr) => arr.findIndex((q) => q.model === p.model) === index
+       );
+
 	const { data: lastSales } = useQuery<unknown[]>({
 		queryKey: ["lastSales"],
 		queryFn: () => statsService.getLast20Sales(),
@@ -166,7 +170,7 @@ export default function CaissePage() {
 
         const onCheckout = () => {
                 const payload = {
-                        mode_paiement: "CB",
+                        mode_paiement: "espece",
                         prix_panier: total,
                         dateAjout: new Date().toISOString().slice(0, 10),
                         items: items.map((it) => ({
@@ -228,18 +232,20 @@ export default function CaissePage() {
 						value={search}
 						onChange={(e) => setSearch(e.target.value)}
 					/>
-                                       {productList.map((p) => (
-                                                        <Card key={p.id} className="w-full">
-                                                                <Typography.Text>{p.model}</Typography.Text>
-								<div className="mt-2 flex gap-2 flex-wrap">
-									{VARIANTS.map((v) => (
-										<Button key={v} onClick={() => onAddItem(p, v)}>
-											{v} ({PRICE_MAP[v]}€)
-										</Button>
-									))}
-								</div>
-							</Card>
-						))}
+                                       <div className="grid grid-cols-2 gap-2">
+                                               {uniqueProducts.map((p) => (
+                                                       <Card key={p.id} className="w-full">
+                                                               <Typography.Text>{p.model}</Typography.Text>
+                                                               <div className="mt-2 flex gap-2 flex-wrap">
+                                                                       {VARIANTS.map((v) => (
+                                                                               <Button key={v} onClick={() => onAddItem(p, v)}>
+                                                                               {v} ({PRICE_MAP[v]}€)
+                                                                               </Button>
+                                                                       ))}
+                                                               </div>
+                                                       </Card>
+                                               ))}
+                                       </div>
 				</Space>
 			</Modal>
 			<Modal


### PR DESCRIPTION
## Summary
- display each model only once when adding items
- show products in a grid layout
- set payments to `espece` for POS checkout
- create new `/Ventes/register` endpoint for recording sales
- adjust frontend service to use the new endpoint

## Testing
- `npm test` *(fails: no test script)*
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bdc1040dc83269180bb94a33cc4ff